### PR TITLE
Add: 一覧画面から遷移できる記事の詳細画面を実装した

### DIFF
--- a/flutter/flutter_project/.gitignore
+++ b/flutter/flutter_project/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 # Miscellaneous
 *.class
 *.log

--- a/flutter/flutter_project/lib/components/article_container.dart
+++ b/flutter/flutter_project/lib/components/article_container.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_project/screens/article_detail_screen.dart';
 import 'package:intl/intl.dart';
 
 import 'package:flutter/material.dart';
@@ -19,61 +20,71 @@ class ArticleContainer extends StatelessWidget {
         horizontal: 16,
       ),
 
-      child: Container(
-        height: 180,
-        padding: const EdgeInsets.symmetric(
-          horizontal: 20,
-          vertical: 16,
+      child: GestureDetector(
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: ((context) => ArticleDetailScreen(article: article))
+            ),
+          );
+        },
+
+        child: Container(
+          height: 180,
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20,
+            vertical: 16,
+          ),
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.black),
+            borderRadius: BorderRadius.circular(32),
+          ),
+
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 投稿日
+              Text(
+                DateFormat('yyyy/MM/dd').format(article.publishedAt),
+                style: const TextStyle(
+                  color: Colors.black,
+                  fontSize: 12,
+                ),
+              ),
+
+              // タイトル
+              Text(
+                article.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+
+              // タグ
+              Text(
+                '#${article.tags.join(' #')}',
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: Colors.black,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+
+              // 作成者
+              Text(
+                article.authorName,
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: Colors.black,
+                )
+              ),
+            ]
+          )
         ),
-        decoration: BoxDecoration(
-          border: Border.all(color: Colors.black),
-          borderRadius: BorderRadius.circular(32),
-        ),
-
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // 投稿日
-            Text(
-              DateFormat('yyyy/MM/dd').format(article.publishedAt),
-              style: const TextStyle(
-                color: Colors.black,
-                fontSize: 12,
-              ),
-            ),
-
-            // タイトル
-            Text(
-              article.title,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                color: Colors.black,
-              ),
-            ),
-
-            // タグ
-            Text(
-              '#${article.tags.join(' #')}',
-              style: const TextStyle(
-                fontSize: 12,
-                color: Colors.black,
-                fontStyle: FontStyle.italic,
-              ),
-            ),
-
-            // 作成者
-            Text(
-              article.authorName,
-              style: const TextStyle(
-                fontSize: 12,
-                color: Colors.black,
-              )
-            ),
-          ]
-        )
       ),
     );
   }

--- a/flutter/flutter_project/lib/components/article_text_container.dart
+++ b/flutter/flutter_project/lib/components/article_text_container.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_project/models/article_text.dart';
+
+class ArticleTextContainer extends StatelessWidget {
+  const ArticleTextContainer({
+    Key? key,
+    required this.currentArticle,
+  }) : super(key: key);
+
+  final ArticleText currentArticle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+        currentArticle.text,
+        style: const TextStyle(
+          fontSize: 12,
+          color: Colors.black,
+        )
+    );
+  }
+}

--- a/flutter/flutter_project/lib/main.dart
+++ b/flutter/flutter_project/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_project/screens/all_articles_screen.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-void main() {
+void main() async {
+  await dotenv.load(fileName: '.env');
   runApp(const MyApp());
 }
 

--- a/flutter/flutter_project/lib/models/article.dart
+++ b/flutter/flutter_project/lib/models/article.dart
@@ -3,6 +3,7 @@ class Article {
   final DateTime publishedAt;
   final String authorName;
   final String linkUrl;
+  final String id;
   final List<String> tags;
 
   Article({
@@ -10,6 +11,7 @@ class Article {
     required this.publishedAt,
     required this.authorName,
     required this.linkUrl,
+    required this.id,
     this.tags = const []
   });
 
@@ -19,6 +21,7 @@ class Article {
       publishedAt: DateTime.parse(json['node']['publishedAt'].toString()),
       authorName: json['node']['author']['urlName'],
       linkUrl: json['node']['linkUrl'],
+      id: json['node']['uuid'],
       tags: List<String>.from(json['node']['tags'].map((tag) => tag['name']))
     );
   }

--- a/flutter/flutter_project/lib/models/article_text.dart
+++ b/flutter/flutter_project/lib/models/article_text.dart
@@ -1,0 +1,9 @@
+class ArticleText {
+  final String text;
+
+  ArticleText({required this.text});
+
+  factory ArticleText.fromJson(Map<String, dynamic> json) {
+    return ArticleText(text: json['body']);
+  }
+}

--- a/flutter/flutter_project/lib/screens/article_detail_screen.dart
+++ b/flutter/flutter_project/lib/screens/article_detail_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_project/models/article_text.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+import 'package:flutter_project/components/article_container.dart';
+import 'package:flutter_project/components/article_text_container.dart';
+import 'package:flutter_project/models/article.dart';
+
+class ArticleDetailScreen extends StatefulWidget {
+  const ArticleDetailScreen({
+    required this.article,
+    super.key
+  });
+
+  final Article article;
+
+  @override
+  State<ArticleDetailScreen> createState() => _ArticleDetailScreenState();
+}
+
+class _ArticleDetailScreenState extends State<ArticleDetailScreen> {
+  ArticleText currentArticle = ArticleText(text: "");
+
+  Future getArticle() async {
+    final res = await getArticleText(widget.article.id);
+    setState(() {
+      currentArticle = res;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    getArticle();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Article Detail')),
+      body: FutureBuilder(
+        future: getArticleText(widget.article.id),
+        builder: (context, snapshot){
+          if(snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: Text("LOADING..."));
+          }else {
+            if(currentArticle.text == "") {
+              return const Center(child: Text("NO Article"));
+            }else {
+              return Column(
+                children: [
+                  Expanded(
+                    child: ListView(
+                      children: [
+                        ArticleContainer(article: widget.article),
+                        ArticleTextContainer(currentArticle: currentArticle)
+                      ],
+                    )
+                  )
+                ],
+              );
+            }
+          }
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final res = await getArticleText(widget.article.id);
+          setState(() {
+            currentArticle = res;
+          });
+        },
+        child: const Icon(Icons.autorenew)
+       ),
+    );
+  }
+}
+
+Future<ArticleText> getArticleText(articleId) async {
+  final uri = Uri.parse('https://qiita.com/api/v2/items/$articleId');
+
+  final String token = dotenv.env['QIITA_ACCESS_TOKEN'] ?? '';
+  final http.Response res = await http.get(uri, headers: {
+    'Authorization': 'Bearer $token',
+  });
+
+  if(res.statusCode == 200) {
+    final dynamic body = jsonDecode(res.body);
+    return ArticleText.fromJson(body);
+  }else {
+    return ArticleText(text: "");
+  }
+}

--- a/flutter/flutter_project/pubspec.lock
+++ b/flutter/flutter_project/pubspec.lock
@@ -62,6 +62,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/flutter/flutter_project/pubspec.yaml
+++ b/flutter/flutter_project/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   http: ^1.1.0
   intl: ^0.18.1
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -61,9 +62,10 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  assets:
+    - .env
+  # - images/a_dot_burr.jpeg
+  # - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
# 追加した機能

- [x] 一覧画面から遷移できる詳細画面を実装した
- [x] 詳細画面では、一覧画面で表示されたいた情報に加えて記事の本文も表示するようにした

# これから追加していく機能

- [ ] 詳細画面からブラウザに遷移して記事のページを表示できるようにする

# 関連Issue
#48 