### PR TITLE
Add: お気に入り一覧画面を作成した

### DIFF
--- a/flutter/flutter_project/lib/components/article_container.dart
+++ b/flutter/flutter_project/lib/components/article_container.dart
@@ -1,8 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
-
-import 'package:flutter/material.dart';
 import 'package:flutter_project/models/article.dart';
 import 'package:flutter_project/screens/article_detail_screen.dart';
 import 'package:flutter_project/models/favorite.dart';
@@ -49,7 +48,8 @@ class _ArticleContainer extends State<ArticleContainer> {
       Favorite(
         title: widget.article.title,
         postTime: DateFormat('yyyy/MM/dd').format(DateTime.now()),
-        url: widget.article.linkUrl
+        url: widget.article.linkUrl,
+        authorName: widget.article.authorName
       )
     ];
   }

--- a/flutter/flutter_project/lib/components/favorite_container.dart
+++ b/flutter/flutter_project/lib/components/favorite_container.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_project/models/favorite.dart';
+import 'package:flutter_project/screens/favorite_screen.dart';
+
+class FavoriteContainer extends StatefulWidget {
+  const FavoriteContainer({
+    Key? key,
+    required this.favorite,
+  }) : super(key: key);
+
+  final Favorite favorite;
+
+  @override
+  State<FavoriteContainer> createState() => _FavoriteContainer();
+}
+
+class _FavoriteContainer extends State<FavoriteContainer> {
+  removeArticle() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    prefs.remove('${widget.favorite.authorName}/${widget.favorite.title}');
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        vertical: 12,
+        horizontal: 16,
+      ),
+
+      child: Container(
+        height: 180,
+        padding: const EdgeInsets.symmetric(
+          horizontal: 20,
+          vertical: 16,
+        ),
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.black),
+          borderRadius: BorderRadius.circular(32),
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              // お気に入りした日
+              Text(
+                widget.favorite.postTime,
+                style: const TextStyle(
+                  color: Colors.black,
+                  fontSize: 12,
+                ),
+              ),
+
+              // タイトル
+              Text(
+                widget.favorite.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+
+              // お気に入り解除ボタン
+              OutlinedButton(
+                onPressed: () {
+                  removeArticle();
+                },
+                child: const Text('お気に入りを外す'),
+                ),
+
+              // ブラウザ遷移ボタン
+              OutlinedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: ((context) => FavoriteScreen(favorite: widget.favorite))
+                    ),
+                  );
+                },
+                child: const Text('ブラウザで見る'),
+              ),
+            ],
+          )
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/flutter_project/lib/main.dart
+++ b/flutter/flutter_project/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_project/screens/all_articles_screen.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+import 'package:flutter_project/screens/all_articles_screen.dart';
+import 'package:flutter_project/screens/favorite_article.dart';
 
 void main() async {
   await dotenv.load(fileName: '.env');
@@ -20,7 +22,44 @@ class MyApp extends StatelessWidget {
         appBarTheme: const AppBarTheme(backgroundColor: Color(0xFF55C500)),
         textTheme: Theme.of(context).textTheme.apply(bodyColor: Colors.white),
       ),
-      home: const AllArticlesScreen(),
+      home: const MyStatefulWidget(),
     );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({Key? key}) : super(key: key);
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  static const _screens = [
+    AllArticlesScreen(),
+    FavoriteArticleScreen()
+  ];
+
+  int _selectedIndex = 0;
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: _screens[_selectedIndex],
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: _selectedIndex,
+          onTap: _onItemTapped,
+          items: const <BottomNavigationBarItem>[
+            BottomNavigationBarItem(icon: Icon(Icons.home), label: 'ホーム'),
+            BottomNavigationBarItem(icon: Icon(Icons.favorite), label: 'お気に入り'),
+          ],
+          type: BottomNavigationBarType.fixed,
+        ));
   }
 }

--- a/flutter/flutter_project/lib/models/favorite.dart
+++ b/flutter/flutter_project/lib/models/favorite.dart
@@ -2,24 +2,28 @@ class Favorite {
   String title;
   String postTime;
   String url;
+  String authorName;
 
   Favorite({
     required this.title,
     required this.postTime,
-    required this.url
+    required this.url,
+    required this.authorName
   });
 
   Map toJson() => {
-    'title': title,
-    'postTime': postTime,
-    'url': url
-  };
+      'title': title,
+      'postTime': postTime,
+      'url': url,
+      'authorName': authorName
+    };
 
-  factory Favorite.fromJson(Map json){
+  factory Favorite.fromJson(Map<String, dynamic> json){
     return Favorite(
       title: json['title'],
       postTime: json['postTime'],
-      url: json['url']
+      url: json['url'],
+      authorName: json['authorName']
     );
   }
 }

--- a/flutter/flutter_project/lib/screens/favorite_article.dart
+++ b/flutter/flutter_project/lib/screens/favorite_article.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
+
+import 'package:flutter_project/models/favorite.dart';
+import 'package:flutter_project/components/favorite_container.dart';
+
+class FavoriteArticleScreen extends StatefulWidget {
+  const FavoriteArticleScreen({super.key});
+
+  @override
+  State<FavoriteArticleScreen> createState() => _FavoriteArticleScreenState();
+}
+
+class _FavoriteArticleScreenState extends State<FavoriteArticleScreen> {
+  List keys = [];
+  List<Favorite> favorites = [];
+  
+  Future getFavoriteArticles() async {
+    if(favorites != []) {
+      favorites = [];
+    }
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    setState(() {
+      prefs.getKeys().forEach((key) {
+        List<String>? result = prefs.getStringList(key);
+        Favorite favorite = result!.map((e) => Favorite.fromJson(jsonDecode(e))).single;
+        favorites.add(favorite);
+      });
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    getFavoriteArticles();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Favorite Articles')),
+        body: Column(
+                children: [
+                  Expanded(
+                    child: ListView(
+                      children: favorites
+                                .map((favorite) => FavoriteContainer(favorite: favorite))
+                                .toList()
+                    ),
+                  ),
+                ],
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () async {
+                  final res = await getFavoriteArticles();
+                  if(res != null) {
+                    setState(() {
+                      favorites = res;
+                    });
+                  }
+                },
+                child: const Icon(Icons.autorenew)
+              ),
+      );
+  }
+}

--- a/flutter/flutter_project/lib/screens/favorite_screen.dart
+++ b/flutter/flutter_project/lib/screens/favorite_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'package:flutter_project/models/favorite.dart';
+
+class FavoriteScreen extends StatelessWidget {
+  const FavoriteScreen({ 
+    super.key,
+    required this.favorite,
+  });
+
+  final Favorite favorite;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Article Page')),
+      body: WebView(initialUrl: favorite.url)
+    );
+  }
+}


### PR DESCRIPTION
# 追加した機能

- [x] ボトムナビゲーションで、トレンド記事一覧画面とお気に入り一覧画面を行き来できるようにした
- [x] お気に入り登録した記事を一覧表示できるようにした
- [x] この画面からもお気に入り解除できるようにした
- [x] この画面からブラウザに遷移して、記事のページを表示できるようにした

# 関連Issue
#50 